### PR TITLE
Remove prop-types from eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
         "react"
     ],
     "rules": {
+        "react/prop-types": "off",
         "semi": [2, "always"]
     }
 }


### PR DESCRIPTION
We aren't using prop-types, so we are removing them from the eslint rules